### PR TITLE
Fix missing namespace for unit tests

### DIFF
--- a/Finance/Finance.UnitTests/FinanceTests.cs
+++ b/Finance/Finance.UnitTests/FinanceTests.cs
@@ -1,5 +1,6 @@
 using Finance.Library;
 using System;
+using System.Text;
 using Xunit;
 
 namespace Finance.UnitTests


### PR DESCRIPTION
## Summary
- add missing `System.Text` namespace

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9288e04483229347f12c5535aff6